### PR TITLE
Created a new Gendarme rule named OverrideToStringMethodRule.

### DIFF
--- a/gendarme/rules/Gendarme.Rules.Design/Gendarme.Rules.Design.csproj
+++ b/gendarme/rules/Gendarme.Rules.Design/Gendarme.Rules.Design.csproj
@@ -54,6 +54,7 @@
     <Compile Include="AvoidRefAndOutParametersRule.cs" />
     <Compile Include="AvoidSmallNamespaceRule.cs" />
     <Compile Include="AvoidVisibleNestedTypesRule.cs" />
+    <Compile Include="OverrideToStringMethodRule.cs" />
     <Compile Include="ConsiderConvertingFieldToNullableRule.cs" />
     <Compile Include="ConsiderConvertingMethodToPropertyRule.cs" />
     <Compile Include="ConsiderUsingStaticTypeRule.cs" />

--- a/gendarme/rules/Gendarme.Rules.Design/OverrideToStringMethodRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Design/OverrideToStringMethodRule.cs
@@ -1,0 +1,84 @@
+﻿//
+// Gendarme.Rules.Design.OverrideToStringMethodRule
+//
+// Authors:
+//    Lex Li <lextudio@gmail.com>
+//    Andreas Noever <andreas.noever@gmail.com>
+//
+//  (C) 2010 Lex Li
+//  (C) 2008 Andreas Noever
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Mono.Cecil;
+using Gendarme.Framework;
+using Gendarme.Framework.Helpers;
+using Gendarme.Framework.Rocks;
+
+namespace Gendarme.Rules.Design
+{
+    /// <summary>
+    /// This rule warns when a type does not override the <c>Object.ToString</c> function.
+    /// </summary>
+    /// <example>
+    /// Bad example:
+    /// <code>
+    /// class DoesNotOverrideEquals 
+    /// {
+    /// }
+    /// </code>
+    /// </example>
+    /// <example>
+    /// Good example:
+    /// <code>
+    /// class OverridesToString 
+    /// {
+    ///    public override string ToString ()
+    ///    {
+    ///        return "My name is OverridesToString";
+    ///    }
+    /// }
+    /// </code>
+    /// </example>
+    [Problem ("This type does not override the ToString method.")]
+    [Solution ("Override the ToString method to help debugging.")]
+    public class OverrideToStringMethodRule : Rule, ITypeRule {
+
+        private readonly MethodSignature _toString = new MethodSignature("ToString", "System.String", new string[0]);
+
+        public RuleResult CheckType (TypeDefinition type)
+        {
+            if (type.IsEnum || type.IsInterface || type.IsDelegate () || type.IsStatic() || type.FullName.Contains("<")) 
+                // the last check replaces: type.FullName.StartsWith("<Module>") || type.FullName.StartsWith("<PrivateImplementationDetails>"))
+            {
+                return RuleResult.DoesNotApply;
+            }
+
+            if (type.HasMethod (_toString))
+            {
+                return RuleResult.Success;
+            }
+            
+            Runner.Report (type, Severity.Low, Confidence.High);
+            return RuleResult.Failure;
+        }
+    }
+}

--- a/gendarme/rules/Gendarme.Rules.Design/Test/OverrideToStringMethodTest.cs
+++ b/gendarme/rules/Gendarme.Rules.Design/Test/OverrideToStringMethodTest.cs
@@ -1,0 +1,87 @@
+﻿//
+// Unit tests for OverrideToStringMethodRule
+//
+// Authors:
+//	Lex Li <lextudio@gmail.com>
+//
+//  (C) 2010 Lex Li
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using Gendarme.Framework;
+using Gendarme.Rules.Design;
+using NUnit.Framework;
+using Test.Rules.Fixtures;
+
+namespace Test.Rules.Design
+{
+    public enum MyEnum
+    {
+        OK,
+        Fail
+    }
+    
+    public class MyGoodOne
+    {
+        public override string ToString()
+        {
+            return base.ToString();
+        }
+    }
+    
+    public interface MyInterface
+    {
+        
+    }
+    
+    public class MyBadOne
+    {
+        
+    }
+    
+    public delegate void MyDelegate(string message);
+    
+    [TestFixture]
+    public class OverrideToStringMethodTest : TypeRuleTestFixture<OverrideToStringMethodRule>
+    {
+        [Test]
+        public void DoesNotApply()
+        {
+            AssertRuleDoesNotApply<MyEnum>();
+            AssertRuleDoesNotApply<MyInterface>();
+            AssertRuleDoesNotApply<MyDelegate>();
+        }
+        
+        [Test]
+        public void Good()
+        {
+            AssertRuleSuccess<MyGoodOne>();
+        }
+        
+        [Test]
+        public void Bad()
+        {
+            AssertRuleFailure<MyBadOne>();
+        }
+    }
+}

--- a/gendarme/rules/Gendarme.Rules.Design/Test/Tests.Rules.Design.csproj
+++ b/gendarme/rules/Gendarme.Rules.Design/Test/Tests.Rules.Design.csproj
@@ -72,6 +72,7 @@
     <Compile Include="MissingAttributeUsageOnCustomAttributeTest.cs" />
     <Compile Include="OperatorEqualsShouldBeOverloadedTest.cs" />
     <Compile Include="OverrideEqualsMethodTest.cs" />
+    <Compile Include="OverrideToStringMethodTest.cs" />
     <Compile Include="PreferEventsOverMethodsTest.cs" />
     <Compile Include="PreferIntegerOrStringForIndexersTest.cs" />
     <Compile Include="PreferXmlAbstractionsTest.cs" />


### PR DESCRIPTION
This rule warns when a type does not override the Object.ToString function.

```
Bad example:

class DoesNotOverrideEquals 
{
}  

Good example:

class OverridesToString 
{
  public override string ToString ()
  {
    return "My name is OverridesToString";
  }
}
```
