### PR TITLE
Fix distribution bug in web frontend component of mono-tools

### DIFF
--- a/webdoc/Makefile.am
+++ b/webdoc/Makefile.am
@@ -3,6 +3,7 @@ webdir=$(prefix)/lib/monodoc/web
 web_DATA = \
 	common.css \
 	edit.aspx \
+	Global.asax \
 	header.aspx \
 	header.html \
 	index.aspx \


### PR DESCRIPTION
Ensure Global.asax is listed in web_DATA in Makefile.am. Otherwise, "make dist" does not include this file in the release tarballs, and the web front-end for monodoc will not run without Global.asax.
