### PR TITLE
Gendarme: Add IDE output format option to TextResultWriter

### DIFF
--- a/gendarme/console/ConsoleRunner.cs
+++ b/gendarme/console/ConsoleRunner.cs
@@ -58,6 +58,7 @@ namespace Gendarme {
 		private bool quiet;
 		private bool version;
 		private bool console;
+		private bool ide_formatting;
 		private List<string> assembly_names;
 
 		static string [] SplitOptions (string value)
@@ -238,6 +239,7 @@ namespace Gendarme {
 				{ "confidence=",v => confidence = ParseConfidence (v) },
 				{ "v|verbose",  v => ++VerbosityLevel },
 				{ "console",	v => console = v != null },
+				{ "ide",	v => ide_formatting = v != null },
 				{ "quiet",	v => quiet = v != null },
 				{ "version",	v => version = v != null },
 				{ "h|?|help",	v => help = v != null },
@@ -340,7 +342,7 @@ namespace Gendarme {
 
 			// generate text report (default, to console, if xml and html aren't specified)
 			if (console || (log_file != null) || ((xml_file == null) && (html_file == null))) {
-				using (TextResultWriter writer = new TextResultWriter (this, log_file)) {
+				using (TextResultWriter writer = new TextResultWriter (this, log_file, ide_formatting)) {
 					writer.Report ();
 				}
 			}
@@ -579,6 +581,7 @@ namespace Gendarme {
 			Console.WriteLine ("\t\t\tFilter defects for the specified confidence levels.");
 			Console.WriteLine ("\t\t\tDefault is 'normal+'");
 			Console.WriteLine ("  --console\t\tShow defects on the console even if --log, --xml or --html are specified.");
+			Console.WriteLine ("  --ide\t\tAdd a line to the console output in a format that IDEs will handle as a build error and link to the item");
 			Console.WriteLine ("  --quiet\t\tUsed to disable progress and other information which is normally written to stdout.");
 			Console.WriteLine ("  --v\t\t\tWhen present additional progress information is written to stdout (can be used multiple times).");
 			Console.WriteLine ("  assemblies\t\tSpecify the assemblies to verify.");

--- a/gendarme/console/TextResultWriter.cs
+++ b/gendarme/console/TextResultWriter.cs
@@ -50,10 +50,12 @@ namespace Gendarme {
 
 		private TextWriter writer;
 		private ColorScheme color_scheme;
+		private bool ide; //True if the output should be ide friendly
 
-		public TextResultWriter (IRunner runner, string fileName)
+		public TextResultWriter (IRunner runner, string fileName, bool ide_formatting)
 			: base (runner, fileName)
 		{
+			ide = ide_formatting;
 			if (String.IsNullOrEmpty (fileName)) {
 				writer = System.Console.Out;
 
@@ -78,8 +80,8 @@ namespace Gendarme {
 		{
 			// casting to Severity int saves a ton of memory since IComparable<T> can be used instead of IComparable
 			var query = from n in Runner.Defects
-				    orderby (int) n.Severity, n.Rule.Name
-				    select n;
+					orderby (int) n.Severity, n.Rule.Name
+					select n;
 			
 			WriteHeader ();
 			int num = 0;
@@ -111,6 +113,12 @@ namespace Gendarme {
 		{
 			IRule rule = defect.Rule;
 
+			string source = defect.Source;
+
+			// Writes an output line in a format that IDEs should recognise
+			if (ide && !String.IsNullOrEmpty(source))   
+				writer.WriteLine("{0}: error: {1}: See the output window for futher information", source.Replace(Symbols.AlmostEqualTo, ""), rule.Name);
+
 			BeginColor (
 				(Severity.Critical == defect.Severity || Severity.High == defect.Severity)
 				? ConsoleColor.DarkRed : ConsoleColor.DarkYellow);
@@ -130,7 +138,6 @@ namespace Gendarme {
 			if (defect.Location != defect.Target)
 				writer.WriteLine ("* Location: {0}", defect.Location);	
 
-			string source = defect.Source;
 			if (!String.IsNullOrEmpty (source))
 				writer.WriteLine ("* Source:   {0}", source);
 

--- a/gendarme/framework/Gendarme.Framework/Symbols.cs
+++ b/gendarme/framework/Gendarme.Framework/Symbols.cs
@@ -39,7 +39,7 @@ namespace Gendarme.Framework {
 		// http://blogs.msdn.com/jmstall/archive/2005/06/19/FeeFee_SequencePoints.aspx
 		private const int PdbHiddenLine = 0xFEEFEE;
 
-		private static string AlmostEqualTo = new string (new char [] { '\u2248' });
+		public static readonly string AlmostEqualTo = new string (new char [] { '\u2248' });
 
 		private static Instruction ExtractFirst (TypeDefinition type)
 		{

--- a/gendarme/swf-wizard-runner/Wizard.cs
+++ b/gendarme/swf-wizard-runner/Wizard.cs
@@ -708,7 +708,7 @@ namespace Gendarme {
 				if (CouldCopyReport (ref text_report_filename, filename))
 					return null;
 
-				return new TextResultWriter (Runner, filename);
+				return new TextResultWriter (Runner, filename, false);
 			default:
 				return null;
 			}


### PR DESCRIPTION
Currently the output from Gendarme is not recognised by IDEs. This change adds the ability to specify a command line option ("--ide") which adds a line to the output which is formatted so that IDEs can parse it. This allows Gendarme to be used as a build step and errors will appear in the build error list and link correctly to the line and file where the error occurred.

This has been tested on SharpDevelop and VS2010. It doesn't work on MonoDevelop but I was unable to find any documentation as to what format it requires for custom tools to generate errors to appear in the error list, or if that is supported at all.
