### PR TITLE
Automake is a horrible piece of software by sociopaths

### DIFF
--- a/Mono.Profiler/Mono.Profiler.Widgets/Makefile.am
+++ b/Mono.Profiler/Mono.Profiler.Widgets/Makefile.am
@@ -9,7 +9,8 @@ CSFLAGS =  -noconfig -codepage:utf8 -warn:4
 ASSEMBLY_MDB = 
 endif
 
-pkglib_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
+programfilesdir = $(pkglibdir)
+programfiles_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
 
 CLEANFILES = $(ASSEMBLY) $(ASSEMBLY_MDB)
 

--- a/Mono.Profiler/heap-snapshot-explorer/Makefile.am
+++ b/Mono.Profiler/heap-snapshot-explorer/Makefile.am
@@ -9,7 +9,8 @@ CSFLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY_MDB = 
 endif
 
-pkglib_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
+programfilesdir = $(pkglibdir)
+programfiles_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
 
 CLEANFILES = $(ASSEMBLY) $(ASSEMBLY_MDB)
 

--- a/Mono.Profiler/heap-snapshot-viewer/Makefile.am
+++ b/Mono.Profiler/heap-snapshot-viewer/Makefile.am
@@ -8,7 +8,8 @@ CSFLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY_MDB = 
 endif
 
-pkglib_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
+programfilesdir = $(pkglibdir)
+programfiles_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
 bin_SCRIPTS = mprof-heap-viewer
 man_MANS=man/man1/mprof-heap-viewer.1
 

--- a/Mono.Profiler/mprof-gui/Makefile.am
+++ b/Mono.Profiler/mprof-gui/Makefile.am
@@ -8,7 +8,8 @@ CSFLAGS =  -noconfig -codepage:utf8 -warn:4
 ASSEMBLY_MDB = 
 endif
 
-pkglib_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
+programfilesdir = $(pkglibdir)
+programfiles_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
 bin_SCRIPTS = emveepee
 
 CLEANFILES = $(ASSEMBLY) $(ASSEMBLY_MDB)

--- a/Mono.Profiler/profiler-decoder-library/Makefile.am
+++ b/Mono.Profiler/profiler-decoder-library/Makefile.am
@@ -9,7 +9,8 @@ CSFLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY_MDB = 
 endif
 
-pkglib_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
+programfilesdir = $(pkglibdir)
+programfiles_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
 
 CLEANFILES = $(ASSEMBLY) $(ASSEMBLY_MDB)
 

--- a/Mono.Profiler/profiler-file-decoder/Makefile.am
+++ b/Mono.Profiler/profiler-file-decoder/Makefile.am
@@ -9,7 +9,8 @@ CSFLAGS = -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY_MDB = 
 endif
 
-pkglib_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
+programfilesdir = $(pkglibdir)
+programfiles_DATA = $(ASSEMBLY) $(ASSEMBLY_MDB)
 bin_SCRIPTS = mprof-decoder
 man_MANS = man/man1/mprof-decoder.1 
 


### PR DESCRIPTION
Automake 1.11.2 breaks the ability to use arch-independent types like SCRIPTS or DATA when installing to pkglibdir. So create a new custom target, programfilesdir, which does the same thing but has no restriction. This prevents a build failure with the newer Automake.
