### PR TITLE
Modify UseCorrectPrefixRule to support classes begining with two letter words starting with I

### DIFF
--- a/gendarme/rules/Gendarme.Rules.Naming/Test/UseCorrectPrefixTest.cs
+++ b/gendarme/rules/Gendarme.Rules.Naming/Test/UseCorrectPrefixTest.cs
@@ -54,6 +54,10 @@ namespace Test.Rules.Naming {
 	public class ILRange {
 	}
 
+	public class InMemoryDoohicky
+	{
+	}
+
 	public interface I {
 	}
 
@@ -102,6 +106,7 @@ namespace Test.Rules.Naming {
 			AssertRuleFailure<CIncorrectClass> (1);
 			AssertRuleFailure<INcorrectClass> (1);
 			AssertRuleSuccess<ILRange> ();
+			AssertRuleSuccess<InMemoryDoohicky> ();
 		}
 
 		[Test]

--- a/gendarme/rules/Gendarme.Rules.Naming/UseCorrectPrefixRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Naming/UseCorrectPrefixRule.cs
@@ -90,9 +90,9 @@ namespace Gendarme.Rules.Naming {
 				return true;
 
 			switch (name [0]) {
-			case 'C':	// MFC like CMyClass - but works for CLSCompliant
-			case 'I':	// interface-like
-				return Char.IsLower (name [1]) == Char.IsLower (name [2]);
+			case 'C':	// MFC like CMyClass should fail - but works for CLSCompliant
+			case 'I':	// interface-like - Classes beginning with In or Is etc should pass, e.g. InMemoryDoohicky
+				return Char.IsLower (name [1]) ? true : Char.IsUpper (name [2]);
 			default:
 				return true;
 			}


### PR DESCRIPTION
This allows classes to begin with I<lower><upper> rather than just
I<upper><upper> or I<lower><lower>. This allows for classnames like
"InMemoryDoohicky", "IsCorrectClassTest"
