### PR TITLE
Add Ignore property to MapAttribute, emit structure definitions in correct order

### DIFF
--- a/create-native-map/src/MapAttribute.cs
+++ b/create-native-map/src/MapAttribute.cs
@@ -38,6 +38,7 @@ using System;
 internal class MapAttribute : Attribute {
 	private string nativeType;
 	private string suppressFlags;
+	private bool ignore;
 
 	public MapAttribute ()
 	{
@@ -55,6 +56,11 @@ internal class MapAttribute : Attribute {
 	public string SuppressFlags {
 		get {return suppressFlags;}
 		set {suppressFlags = value;}
+	}
+
+	public bool Ignore {
+		get {return ignore;}
+		set {ignore = value;}
 	}
 }
 


### PR DESCRIPTION
- [Map (Ignore=true)] can be used to ignore a field when generating the C wrapper structure. This is useful for structures with LayoutKind.Explicit.
- When emitting the C wrapper structures make sure all needed types are emitted before emitting a structure.

This changes are needed for https://github.com/mono/mono/pull/221
