### PR TITLE
AvoidUnusedPrivateFieldsRule scans nested types for private fields usage.

### DIFF
--- a/gendarme/rules/Gendarme.Rules.Performance/Test/AvoidUnusedPrivateFieldsTest.cs
+++ b/gendarme/rules/Gendarme.Rules.Performance/Test/AvoidUnusedPrivateFieldsTest.cs
@@ -182,5 +182,26 @@ namespace Test.Rules.Performance {
 		{
 				AssertRuleSuccess<FieldsUsedInNested> ();
 		}
+		
+		class CompilerGenerated {
+			public string Name { get; set; }
+		}
+		
+		[Test]
+		public void ClassWithCompilerGeneratedFields ()
+		{
+			AssertRuleSuccess<CompilerGenerated> ();
+		}
+		
+		class CompilerGeneratedAndUnused {
+			private int number;
+			public string Name { get; set; }
+		}
+		
+		[Test]
+		public void ClassWithCompilerGeneratedFieldsAndUnusedPrivate ()
+		{
+			AssertRuleFailure<CompilerGeneratedAndUnused> (1);
+		}
 	}
 }


### PR DESCRIPTION
In the discussion [1] it was reported that AvoidUnusedPrivateFieldsRule fails when a private field is accessed only in a coroutine, this is because AvoidUnusedPrivateFieldsRule didn't check nested types, which have access to private fields. 

Fix seems to be straightforward: the piece of code that inspects the checked type itself for private fields usage was refactored into a method (CheckFieldsUsageInType) and is now used to check also all the nested types of the checked type.

[1] http://groups.google.com/group/gendarme/browse_thread/thread/2625c1ed5c5e1987
