### PR TITLE
Add -qs to grep call in conditional to silence it

### DIFF
--- a/docbrowser/monodoc.in
+++ b/docbrowser/monodoc.in
@@ -75,7 +75,7 @@ elif test x@MOZILLA_HOME@ != x; then
     if [ -f @MOZILLA_HOME@/chrome/comm.jar ]; then
         MOZILLA_HOME=@MOZILLA_HOME@
     fi 
-elif grep GRE_PATH /etc/gre.d/*.conf > /dev/null ; then
+elif grep -qs GRE_PATH /etc/gre.d/*.conf > /dev/null ; then
 	MOZILLA_HOME=$(grep -h GRE_PATH= /etc/gre.d/*.conf | cut -d '"' -f 2 -d = | head -n 1)
 elif [ $(which xulrunner 2> /dev/null) ] > /dev/null ; then
     MOZILLA_FIVE_HOME=`getdirectory xulrunner`


### PR DESCRIPTION
This prevents a strange (albeit harmless) warning when, for example,
/etc/gre.d/ does not exist.
