### PR TITLE
Fix for monodoc browser quit issue. Fixes Xamarin bug #5482.

### DIFF
--- a/docbrowser/browser.cs
+++ b/docbrowser/browser.cs
@@ -946,6 +946,7 @@ ExtLoop:
 	void delete_event_cb (object o, DeleteEventArgs args)
 	{
 		Application.Quit ();
+		args.RetVal = true;
 	}
 	void on_print_activate (object sender, EventArgs e) 
 	{


### PR DESCRIPTION
This fixes the "MonoDoc exited with a exit code = 134." bug.
