### PR TITLE
Restore behaviour when not passing a --docrootdir parameter from Mono 2.8 when running on Mono 3.0+

### DIFF
--- a/docbrowser/browser.cs
+++ b/docbrowser/browser.cs
@@ -119,6 +119,9 @@ class Driver {
 
 		List<string> topics = p.Parse (args);
 
+		if (basedir == null)
+			basedir = Directory.GetParent (System.Reflection.Assembly.GetExecutingAssembly ().Location).FullName;
+
 		if (show_version) {
 			Console.WriteLine ("Mono Documentation Browser");
 			Version ver = Assembly.GetExecutingAssembly ().GetName ().Version;


### PR DESCRIPTION
Since Mono 3.0, running monodoc without specifying --docrootdir has caused an ArgumentNullException. This works around it.
