### PR TITLE
README.md markdown syntax fix

### DIFF
--- a/gendarme/rules/README.md
+++ b/gendarme/rules/README.md
@@ -1,31 +1,30 @@
 # Gendarme Rules Assemblies
 
-Documentation for each assembly is available on [[Gendarme|http://www.mono-project.com/Gendarme]]'s wiki.
+Documentation for each assembly is available on [Gendarme](http://www.mono-project.com/Gendarme)'s wiki.
 
-* [[Gendarme.Rules.BadPractice|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.BadPractice(git)]]
-* [[Gendarme.Rules.Concurrency|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Concurrency(git)]]
-* [[Gendarme.Rules.Correctness|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Correctness(git)]]
-* [[Gendarme.Rules.Design|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design(git)]]
-* [[Gendarme.Rules.Design.Generic|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design.Generic(git)]]
-* [[Gendarme.Rules.Design.Linq|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design.Linq(git)]]
-* [[Gendarme.Rules.Exceptions|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Exceptions(git)]]
-* [[Gendarme.Rules.Gendarme|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Gendarme(git)]]
-* [[Gendarme.Rules.Globalization|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Globalization(git)]]
-* [[Gendarme.Rules.Interoperability|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Interoperability(git)]]
-* [[Gendarme.Rules.Interoperability.Com|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Interoperability.Com(git)]]
-* [[Gendarme.Rules.Maintainability|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Maintainability(git)]]
-* [[Gendarme.Rules.NUnit|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.NUnit(git)]]
-* [[Gendarme.Rules.Naming|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Naming(git)]]
-* [[Gendarme.Rules.Performance|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Performance(git)]]
-* [[Gendarme.Rules.Portability|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Portability(git)]]
-* [[Gendarme.Rules.Security|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Security(git)]]
-* [[Gendarme.Rules.Security.Cas|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Security.Cas(git)]]
-* [[Gendarme.Rules.Serialization|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Serialization(git)]]
-* [[Gendarme.Rules.Smells|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Smells(git)]]
-* [[Gendarme.Rules.Ui|https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Ui(git)]]
-
+* [Gendarme.Rules.BadPractice](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.BadPractice%28git%29)
+* [Gendarme.Rules.Concurrency](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Concurrency%28git%29)
+* [Gendarme.Rules.Correctness](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Correctness%28git%29)
+* [Gendarme.Rules.Design](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design%28git%29)
+* [Gendarme.Rules.Design.Generic](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design.Generic%28git%29)
+* [Gendarme.Rules.Design.Linq](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design.Linq%28git%29)
+* [Gendarme.Rules.Exceptions](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Exceptions%28git%29)
+* [Gendarme.Rules.Gendarme](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Gendarme%28git%29)
+* [Gendarme.Rules.Globalization](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Globalization%28git%29)
+* [Gendarme.Rules.Interoperability](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Interoperability%28git%29)
+* [Gendarme.Rules.Interoperability.Com](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Interoperability.Com%28git%29)
+* [Gendarme.Rules.Maintainability](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Maintainability%28git%29)
+* [Gendarme.Rules.NUnit](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.NUnit%28git%29)
+* [Gendarme.Rules.Naming](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Naming%28git%29)
+* [Gendarme.Rules.Performance](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Performance%28git%29)
+* [Gendarme.Rules.Portability](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Portability%28git%29)
+* [Gendarme.Rules.Security](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Security%28git%29)
+* [Gendarme.Rules.Security.Cas](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Security.Cas%28git%29)
+* [Gendarme.Rules.Serialization](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Serialization%28git%29)
+* [Gendarme.Rules.Smells](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Smells%28git%29)
+* [Gendarme.Rules.Ui](https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Ui%28git%29)
 
 ## Feedback
 
-Please report any documentation errors, typos or suggestions to the [[Gendarme Mailing List|https://groups.google.com/forum/?fromgroups#!forum/gendarme]]. Thanks!
+Please report any documentation errors, typos or suggestions to the [Gendarme Mailing List](https://groups.google.com/forum/?fromgroups#!forum/gendarme). Thanks!
 


### PR DESCRIPTION
use markdown links, had to URL escape `...(git)` as `...%28git%29` to get the github markdown renderer to display the right links.