### PR TITLE
fixing make and make install of mono-tools against Mono 3.2.x

### DIFF
--- a/Mono.Profiler/Mono.Profiler.Widgets/Makefile.am
+++ b/Mono.Profiler/Mono.Profiler.Widgets/Makefile.am
@@ -56,7 +56,7 @@ build_references = $(addprefix /r:, $(PROJECT_REFERENCES)) $(REFERENCES)
 
 $(ASSEMBLY) $(ASSEMBLY_MDB): $(build_sources) $(build_resources)
 	mkdir -p $(BUILDDIR)
-	$(GMCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:library $(build_sources) $(build_resources_args) $(build_references)
+	$(MCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:library $(build_sources) $(build_resources_args) $(build_references)
 
 EXTRA_DIST = Mono.Profiler.Widgets.csproj $(FILES) $(RESOURCES)
 

--- a/Mono.Profiler/heap-snapshot-explorer/Makefile.am
+++ b/Mono.Profiler/heap-snapshot-explorer/Makefile.am
@@ -51,6 +51,6 @@ build_references = $(addprefix /r:,$(PROJECT_REFERENCES)) $(PACKAGE_REFERENCES)
 
 $(ASSEMBLY) $(ASSEMBLY_MDB): $(build_sources) $(build_resources) $(PROJECT_REFERENCES)
 	mkdir -p $(BUILDDIR)
-	$(GMCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:library $(build_sources) $(build_resources_args) $(build_references)
+	$(MCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:library $(build_sources) $(build_resources_args) $(build_references)
 
 EXTRA_DIST = heap-snapshot-explorer.csproj $(FILES) $(RESOURCES)

--- a/Mono.Profiler/heap-snapshot-viewer/Makefile.am
+++ b/Mono.Profiler/heap-snapshot-viewer/Makefile.am
@@ -48,7 +48,7 @@ build_references = $(addprefix -r:, $(PROJECT_REFERENCES)) $(REFERENCES)
 
 $(ASSEMBLY) $(ASSEMBLY_MDB): $(build_sources) $(build_resources) $(PROJECT_REFERENCES)
 	mkdir -p $(shell dirname $(ASSEMBLY))
-	$(GMCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:exe $(build_sources) $(build_resources_args) $(build_references)
+	$(MCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:exe $(build_sources) $(build_resources_args) $(build_references)
 
 EXTRA_DIST = heap-snapshot-viewer.csproj $(FILES) $(RESOURCES) $(man_MANS)
 

--- a/Mono.Profiler/mprof-gui/Makefile.am
+++ b/Mono.Profiler/mprof-gui/Makefile.am
@@ -41,7 +41,7 @@ build_references = $(addprefix -r:, $(PROJECT_REFERENCES)) $(REFERENCES)
 
 $(ASSEMBLY) $(ASSEMBLY_MDB): $(build_sources) $(build_resources) $(PROJECT_REFERENCES)
 	mkdir -p $(shell dirname $(ASSEMBLY))
-	$(GMCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:exe $(build_sources) $(build_resources_args) $(build_references)
+	$(MCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:exe $(build_sources) $(build_resources_args) $(build_references)
 
 EXTRA_DIST = mprof-gui.csproj $(FILES) $(RESOURCES)
 

--- a/Mono.Profiler/profiler-decoder-library/Makefile.am
+++ b/Mono.Profiler/profiler-decoder-library/Makefile.am
@@ -33,7 +33,7 @@ build_references = $(addprefix /r:, $(REFERENCES))
 
 $(ASSEMBLY) $(ASSEMBLY_MDB): $(build_sources) 
 	mkdir -p $(BUILDDIR)
-	$(GMCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:library $(build_sources) $(build_references)
+	$(MCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:library $(build_sources) $(build_references)
 
 EXTRA_DIST = profiler-decoder-library.csproj $(FILES) $(RESOURCES)
 

--- a/Mono.Profiler/profiler-file-decoder/Makefile.am
+++ b/Mono.Profiler/profiler-file-decoder/Makefile.am
@@ -32,7 +32,7 @@ build_references = $(addprefix /r:, $(PROJECT_REFERENCES))
 
 $(ASSEMBLY) $(ASSEMBLY_MDB): $(build_sources) $(DLL_REFERENCES) $(PROJECT_REFERENCES)
 	mkdir -p $(shell dirname $(ASSEMBLY))
-	$(GMCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:exe $(build_sources) $(build_references)
+	$(MCS) $(CSFLAGS) -out:$(ASSEMBLY) -target:exe $(build_sources) $(build_references)
 
 EXTRA_DIST = profiler-file-decoder.csproj $(FILES) $(RESOURCES) $(man_MANS)
 

--- a/create-native-map/src/Makefile.am
+++ b/create-native-map/src/Makefile.am
@@ -17,7 +17,7 @@ REFS = -r:Mono.Posix.dll
 all: $(EXE)
 
 $(EXE) : $(cnm_build_sources)
-	$(GMCS) $(MCS_FLAGS) -d:TRACE -debug+ -out:$@ -target:exe $(REFS) $(cnm_build_sources)
+	$(MCS) $(MCS_FLAGS) -d:TRACE -debug+ -out:$@ -target:exe $(REFS) $(cnm_build_sources)
 
 assemblydir = $(prefix)/lib/create-native-map
 assembly_DATA = $(EXE) MapAttribute.cs

--- a/docbrowser/Makefile.am
+++ b/docbrowser/Makefile.am
@@ -1,9 +1,9 @@
 monodocdir=$(prefix)/lib/monodoc
 
 if DMCS_PRESENT
-COMPILER=$(DMCS)
+COMPILER=$(MCS)
 else
-COMPILER=$(GMCS)
+COMPILER=$(MCS)
 endif
 
 SUBDIRS=theme-icons

--- a/gendarme/swf-wizard-runner/Makefile.am
+++ b/gendarme/swf-wizard-runner/Makefile.am
@@ -55,7 +55,7 @@ wizard_icon = Resources/gendarme.ico
 wizard_build_icon = $(addprefix $(srcdir)/, $(wizard_icon))
 
 ../bin/gendarme-wizard.exe: $(wizard_build_sources) $(wizard_resources) Wizard.resources Properties/Resources.resources $(wizard_build_xsl) $(wizard_build_icon)
-	$(GMCS) -debug -target:winexe -r:$(CECIL_ASM) -r:../bin/Gendarme.Framework.dll \
+	$(MCS) -debug -target:winexe -r:$(CECIL_ASM) -r:../bin/Gendarme.Framework.dll \
 		-r:System.Core.dll -r:System.Xml.Linq.dll -r:System.Windows.Forms.dll -r:System.Drawing.dll -r:System.Xml.dll \
 		-resource:$(wizard_build_xsl) -resource:Wizard.resources,Gendarme.Wizard.resources \
 		-resource:Properties/Resources.resources,Gendarme.Properties.Resources.resources \

--- a/ilcontrast/Makefile.am
+++ b/ilcontrast/Makefile.am
@@ -47,7 +47,7 @@ sources =				\
 build_sources = Global.cs $(addprefix $(srcdir)/, $(sources))
 
 ilcontrast.exe: $(build_sources)
-	$(GMCS) -out:ilcontrast.exe $(references) $(resources) $(build_sources)
+	$(MCS) -out:ilcontrast.exe $(references) $(resources) $(build_sources)
 
 Global.cs: Global.cs.in
 	sed -e "s|\@VERSION\@|$(VERSION)|" $< > $@

--- a/minvoke/Makefile.am
+++ b/minvoke/Makefile.am
@@ -18,13 +18,13 @@ retargetassembly_exe_sources = \
 EXTRA_DIST = $(minvoke_sources) $(mapassembly_dll_souorces) $(retargetassembly_exe_sources) minvoke.in
 
 MapAssembly.dll: $(mapassembly_dll_sources) 
-	$(GMCS) -noconfig -codepage:utf8 -warn:4 -optimize+ -target:library -out:MapAssembly.dll $(mapassembly_dll_sources)
+	$(MCS) -noconfig -codepage:utf8 -warn:4 -optimize+ -target:library -out:MapAssembly.dll $(mapassembly_dll_sources)
 
 RetargetAssembly.exe: $(retargetassembly_exe_sources)
-	$(GMCS) -noconfig -codepage:utf8 -warn:4 -optimize+ -target:exe -out:RetargetAssembly.exe $(retargetassembly_exe_sources)
+	$(MCS) -noconfig -codepage:utf8 -warn:4 -optimize+ -target:exe -out:RetargetAssembly.exe $(retargetassembly_exe_sources)
 
 minvoke.exe: $(minvoke_sources);
-	$(GMCS) -noconfig -codepage:utf8 -warn:4 -optimize+ -debug -define:DEBUG -target:exe -out:minvoke.exe $(minvoke_sources) -r:System.Core -r:$(CECIL_ASM)
+	$(MCS) -noconfig -codepage:utf8 -warn:4 -optimize+ -debug -define:DEBUG -target:exe -out:minvoke.exe $(minvoke_sources) -r:System.Core -r:$(CECIL_ASM)
 
 
 test: minvoke.exe MapAssembly.dll RetargetAssembly.exe

--- a/mperfmon/Makefile.am
+++ b/mperfmon/Makefile.am
@@ -29,5 +29,5 @@ assemblies = -r:System -r:System.Xml -r:Mono.Cairo -r:Mono.Posix
 ress= $(foreach res,$(mperfmon_resources), $(addprefix -resource:,$(res)),$(notdir $(res)))
 
 mperfmon.exe: $(mperfmon_sources) $(mperfmon_resources)
-	$(GMCS) -noconfig -codepage:utf8 -warn:4 -optimize+ -debug -define:DEBUG -target:exe -out:mperfmon.exe $(mperfmon_sources) $(ress) $(packages) $(assemblies)
+	$(MCS) -noconfig -codepage:utf8 -warn:4 -optimize+ -debug -define:DEBUG -target:exe -out:mperfmon.exe $(mperfmon_sources) $(ress) $(packages) $(assemblies)
 

--- a/webdoc/Makefile.am
+++ b/webdoc/Makefile.am
@@ -117,18 +117,14 @@ install-data-hook:
 	 $(INSTALL_DATA) $(srcdir)/App_Code/Plugins/*cs                                         $(DESTDIR)$(webdir)/App_Code/Plugins
 	 $(INSTALL_DATA) $(srcdir)/views/*css                                                   $(DESTDIR)$(webdir)/views
 	 $(INSTALL_DATA) $(srcdir)/views/*js                                                    $(DESTDIR)$(webdir)/views
-	 $(INSTALL_DATA) $(srcdir)/views/*html                                                  $(DESTDIR)$(webdir)/views
 	 $(INSTALL_DATA) $(srcdir)/views/images/*png                                            $(DESTDIR)$(webdir)/views/images
-	 $(INSTALL_DATA) $(srcdir)/views/images/*gif                                            $(DESTDIR)$(webdir)/views/images
+	 $(INSTALL_DATA) $(srcdir)/views/images/*ico                                            $(DESTDIR)$(webdir)/views/images
 	 $(INSTALL_DATA) $(srcdir)/skins/mono-external/header*                                  $(DESTDIR)$(webdir)/skins/mono-external
 	 $(INSTALL_DATA) $(srcdir)/skins/mono-external/footer*                                  $(DESTDIR)$(webdir)/skins/mono-external
 	 $(INSTALL_DATA) $(srcdir)/skins/mono-external/*css                                     $(DESTDIR)$(webdir)/skins/mono-external
-	 $(INSTALL_DATA) $(srcdir)/skins/mono-external/*js                                      $(DESTDIR)$(webdir)/skins/mono-external
 	 $(INSTALL_DATA) $(srcdir)/skins/mono-external/images/*png                              $(DESTDIR)$(webdir)/skins/mono-external/images
 	 $(INSTALL_DATA) $(srcdir)/skins/mono-external/images/*gif                              $(DESTDIR)$(webdir)/skins/mono-external/images
-	 $(INSTALL_DATA) $(srcdir)/plugins/iframe-plugins/*css                                  $(DESTDIR)$(webdir)/plugins/iframe-plugin
 	 $(INSTALL_DATA) $(srcdir)/plugins/iframe-plugin/*js                                    $(DESTDIR)$(webdir)/plugins/iframe-plugin
-	 $(INSTALL_DATA) $(srcdir)/plugins/iframe-plugin/*html                                  $(DESTDIR)$(webdir)/plugins/iframe-plugin
 	 $(INSTALL_DATA) $(srcdir)/plugins/tooltip-plugin/*js                                    $(DESTDIR)$(webdir)/plugins/tooltip-plugin
 	 $(INSTALL_DATA) $(srcdir)/plugins/sidebar-plugin/*css                                  $(DESTDIR)$(webdir)/plugins/sidebar-plugin
 	 $(INSTALL_DATA) $(srcdir)/plugins/sidebar-plugin/*js                                   $(DESTDIR)$(webdir)/plugins/sidebar-plugin


### PR DESCRIPTION
I needed to make these changes so that I was able to build mono-tools against Mono 3.2.5.