### PR TITLE
Gendarme - allow many assemblies with the same name

### DIFF
--- a/gendarme/framework/Gendarme.Framework/AssemblyResolver.cs
+++ b/gendarme/framework/Gendarme.Framework/AssemblyResolver.cs
@@ -75,7 +75,7 @@ namespace Gendarme.Framework {
 			if (assembly == null)
 				throw new ArgumentNullException ("assembly");
 
-			assemblies.Add (assembly.Name.Name, assembly);
+			assemblies[assembly.Name.Name] = assembly;
 			string location = Path.GetDirectoryName (assembly.MainModule.FullyQualifiedName);
 			AddSearchDirectory (location);
 		}


### PR DESCRIPTION
This is useful when you want gendarme to analysis the output from a build which emits artifacts into different directories and some of the assemblies are shared between the projects.

Currently it throws an unhandled exception so this does change should not have any regression issues.