### PR TITLE
Changes to create-native-map

### DIFF
--- a/create-native-map/man/create-native-map.1
+++ b/create-native-map/man/create-native-map.1
@@ -435,6 +435,9 @@ becomes
 	}
 
 .fi
+For classes, the conversion functions will only copy fields declared in the class itself. Fields declared in parent classes will not be copied. (This is because
+.I create-native-map
+does not know how the inheritance is implemented in C. Therefore copying fields from parent classes is left to the caller of the conversion functions.)
 .TP
 Fields
 If a field (1) has the

--- a/create-native-map/src/TestMap.cs
+++ b/create-native-map/src/TestMap.cs
@@ -16,7 +16,7 @@ namespace MakeMap.Test {
 			HandleRef h, ForDelegate fd);
 
 	[Map]
-	enum TestEnum : long {
+	public enum TestEnum : long {
 		Foo,
 		Bar,
 		Baz,
@@ -24,7 +24,7 @@ namespace MakeMap.Test {
 	}
 
 	[Map, Flags]
-	enum SimpleFlagsEnum {
+	public enum SimpleFlagsEnum {
 		None  = 0,
 		A     = 1,
 		B     = 2,
@@ -33,7 +33,7 @@ namespace MakeMap.Test {
 	}
 
 	[Map, Flags]
-	enum FlagsEnum {
+	public enum FlagsEnum {
 		None  = 0,
 		A     = 1,
 		B     = 2,
@@ -110,6 +110,23 @@ namespace MakeMap.Test {
 		[DllImport ("NativeLib")]
 		private static extern void exclude_native_symbol ();
 	}
+
+	[Map]
+	enum InternalEnum : long {
+		Foo,
+	}
+
+	[Map ("struct parent")]
+	[StructLayout (LayoutKind.Sequential)]
+	public class Parent {
+		public int i;
+	}
+
+	[Map ("struct child")]
+	[StructLayout (LayoutKind.Sequential)]
+	public class Child : Parent {
+		public int j;
+	}
 }
 
 // Testing namespace renaming; this should be NSTo within test.h
@@ -121,8 +138,7 @@ namespace MakeMap.ToBeRenamed {
 	}
 
 	[Map]
-	enum Colors {
+	public enum Colors {
 		Red, Blue, Green
 	}
 }
-

--- a/create-native-map/src/test.c.ref
+++ b/create-native-map/src/test.c.ref
@@ -194,6 +194,36 @@
   } G_STMT_END
 #endif /* def DEBUG */
 
+#ifdef HAVE_STRUCT_CHILD
+int
+MakeMap_Test_FromChild (struct MakeMap_Test_Child *from, struct child *to)
+{
+	_cnm_return_val_if_overflow (int, from->j, -1);
+
+	memset (to, 0, sizeof(*to));
+
+	to->j = from->j;
+
+	return 0;
+}
+#endif /* ndef HAVE_STRUCT_CHILD */
+
+
+#ifdef HAVE_STRUCT_CHILD
+int
+MakeMap_Test_ToChild (struct child *from, struct MakeMap_Test_Child *to)
+{
+	_cnm_return_val_if_overflow (int, from->j, -1);
+
+	memset (to, 0, sizeof(*to));
+
+	to->j = from->j;
+
+	return 0;
+}
+#endif /* ndef HAVE_STRUCT_CHILD */
+
+
 int MakeMap_Test_FromFlagsEnum (int x, int *r)
 {
 	*r = 0;
@@ -430,6 +460,62 @@ MakeMap_Test_ToFooHolder (struct foo_holder *from, struct MakeMap_Test_FooHolder
 	return 0;
 }
 #endif /* ndef HAVE_STRUCT_FOO_HOLDER */
+
+
+int MakeMap_Test_FromInternalEnum (gint64 x, gint64 *r)
+{
+	*r = 0;
+	if (x == MakeMap_Test_InternalEnum_Foo)
+#ifdef Foo
+		{*r = Foo; return 0;}
+#else /* def Foo */
+		{errno = EINVAL; return -1;}
+#endif /* ndef Foo */
+	if (x == 0)
+		return 0;
+	errno = EINVAL; return -1;
+}
+
+int MakeMap_Test_ToInternalEnum (gint64 x, gint64 *r)
+{
+	*r = 0;
+	if (x == 0)
+		return 0;
+#ifdef Foo
+	if (x == Foo)
+		{*r = MakeMap_Test_InternalEnum_Foo; return 0;}
+#endif /* ndef Foo */
+	errno = EINVAL; return -1;
+}
+
+#ifdef HAVE_STRUCT_PARENT
+int
+MakeMap_Test_FromParent (struct MakeMap_Test_Parent *from, struct parent *to)
+{
+	_cnm_return_val_if_overflow (int, from->i, -1);
+
+	memset (to, 0, sizeof(*to));
+
+	to->i = from->i;
+
+	return 0;
+}
+#endif /* ndef HAVE_STRUCT_PARENT */
+
+
+#ifdef HAVE_STRUCT_PARENT
+int
+MakeMap_Test_ToParent (struct parent *from, struct MakeMap_Test_Parent *to)
+{
+	_cnm_return_val_if_overflow (int, from->i, -1);
+
+	memset (to, 0, sizeof(*to));
+
+	to->i = from->i;
+
+	return 0;
+}
+#endif /* ndef HAVE_STRUCT_PARENT */
 
 
 int MakeMap_Test_FromSimpleFlagsEnum (int x, int *r)

--- a/create-native-map/src/test.cs.ref
+++ b/create-native-map/src/test.cs.ref
@@ -22,6 +22,22 @@ namespace Mono.Unix.Native {
 				Locale.GetText ("Current platform doesn't support this value."));
 		}
 
+		[DllImport (LIB, EntryPoint="MakeMap_Test_FromChild")]
+		private static extern int FromChild (Child source, IntPtr destination);
+
+		public static bool TryCopy (Child source, IntPtr destination)
+		{
+			return FromChild (source, destination) == 0;
+		}
+
+		[DllImport (LIB, EntryPoint="MakeMap_Test_ToChild")]
+		private static extern int ToChild (IntPtr source, Child destination);
+
+		public static bool TryCopy (IntPtr source, Child destination)
+		{
+			return ToChild (source, destination) == 0;
+		}
+
 		[DllImport (LIB, EntryPoint="MakeMap_Test_FromFlagsEnum")]
 		private static extern int FromFlagsEnum (FlagsEnum value, out Int32 rval);
 
@@ -84,6 +100,54 @@ namespace Mono.Unix.Native {
 		public static bool TryCopy (IntPtr source, out FooHolder destination)
 		{
 			return ToFooHolder (source, out destination) == 0;
+		}
+
+		[DllImport (LIB, EntryPoint="MakeMap_Test_FromInternalEnum")]
+		private static extern int FromInternalEnum (InternalEnum value, out Int64 rval);
+
+		internal static bool TryFromInternalEnum (InternalEnum value, out Int64 rval)
+		{
+			return FromInternalEnum (value, out rval) == 0;
+		}
+
+		internal static Int64 FromInternalEnum (InternalEnum value)
+		{
+			Int64 rval;
+			if (FromInternalEnum (value, out rval) == -1)
+				ThrowArgumentException (value);
+			return rval;
+		}
+
+		[DllImport (LIB, EntryPoint="MakeMap_Test_ToInternalEnum")]
+		private static extern int ToInternalEnum (Int64 value, out InternalEnum rval);
+
+		internal static bool TryToInternalEnum (Int64 value, out InternalEnum rval)
+		{
+			return ToInternalEnum (value, out rval) == 0;
+		}
+
+		internal static InternalEnum ToInternalEnum (Int64 value)
+		{
+			InternalEnum rval;
+			if (ToInternalEnum (value, out rval) == -1)
+				ThrowArgumentException (value);
+			return rval;
+		}
+
+		[DllImport (LIB, EntryPoint="MakeMap_Test_FromParent")]
+		private static extern int FromParent (Parent source, IntPtr destination);
+
+		public static bool TryCopy (Parent source, IntPtr destination)
+		{
+			return FromParent (source, destination) == 0;
+		}
+
+		[DllImport (LIB, EntryPoint="MakeMap_Test_ToParent")]
+		private static extern int ToParent (IntPtr source, Parent destination);
+
+		public static bool TryCopy (IntPtr source, Parent destination)
+		{
+			return ToParent (source, destination) == 0;
 		}
 
 		[DllImport (LIB, EntryPoint="MakeMap_Test_FromSimpleFlagsEnum")]

--- a/create-native-map/src/test.h.ref
+++ b/create-native-map/src/test.h.ref
@@ -60,6 +60,13 @@ enum MakeMap_Test_FlagsEnum {
 int MakeMap_Test_FromFlagsEnum (int x, int *r);
 int MakeMap_Test_ToFlagsEnum (int x, int *r);
 
+enum MakeMap_Test_InternalEnum {
+	MakeMap_Test_InternalEnum_Foo           = 0x0000000000000000,
+	#define MakeMap_Test_InternalEnum_Foo     MakeMap_Test_InternalEnum_Foo
+};
+int MakeMap_Test_FromInternalEnum (gint64 x, gint64 *r);
+int MakeMap_Test_ToInternalEnum (gint64 x, gint64 *r);
+
 enum MakeMap_Test_SimpleFlagsEnum {
 	MakeMap_Test_SimpleFlagsEnum_A             = 0x00000001,
 	#define MakeMap_Test_SimpleFlagsEnum_A       MakeMap_Test_SimpleFlagsEnum_A
@@ -105,9 +112,11 @@ int MakeMap_Rename_ToColors (int x, int *r);
  */
 
 struct MakeMap_Test_Baz;
+struct MakeMap_Test_Child;
 struct MakeMap_Test_Foo;
 struct MakeMap_Test_FooHolder;
 struct MakeMap_Test_ForDelegate;
+struct MakeMap_Test_Parent;
 struct MakeMap_Test_Qux;
 struct MakeMap_Rename_Stat;
 
@@ -115,8 +124,10 @@ struct MakeMap_Rename_Stat;
  * Inferred Structure Declarations
  */
 
+struct child;
 struct foo;
 struct foo_holder;
+struct parent;
 
 /*
  * Delegate Declarations
@@ -147,6 +158,17 @@ struct MakeMap_Test_Baz {
 	DelRefArrayBaz b8;
 };
 
+struct MakeMap_Test_Child {
+	int i;
+	int j;
+};
+
+int
+MakeMap_Test_FromChild (struct MakeMap_Test_Child* from, struct child *to);
+int
+MakeMap_Test_ToChild (struct child *from, struct MakeMap_Test_Child* to);
+
+
 struct MakeMap_Test_Foo {
 	int    foo;
 	void*  p;
@@ -173,6 +195,16 @@ MakeMap_Test_ToFooHolder (struct foo_holder *from, struct MakeMap_Test_FooHolder
 struct MakeMap_Test_ForDelegate {
 	int i;
 };
+
+struct MakeMap_Test_Parent {
+	int i;
+};
+
+int
+MakeMap_Test_FromParent (struct MakeMap_Test_Parent* from, struct parent *to);
+int
+MakeMap_Test_ToParent (struct parent *from, struct MakeMap_Test_Parent* to);
+
 
 struct MakeMap_Test_Qux {
 	int                      i;


### PR DESCRIPTION
- Use CompareOptions.OrdinalIgnoreCase instead of
  CompareOptions.Ordinal | CompareOptions.IgnoreCase (which is no longer
  supported by newer mono versions)
  This is needed to make the code work on current mono master.

- Make sure enum hex values are lowercase on newer mono versions
  This is needed to make the code produce the lowercase enum values (like they are in the current mono git) on current mono master.

These changes are needed for a the second part of the posix socket pull request:
- Do not create conversion calls for inherited fields
- Allow [Map] for internal enums
