### PR TITLE
a11y: Increase smallest font size

### DIFF
--- a/gendarme/rules/Gendarme.Rules.Performance/Test/AvoidLargeStructureTest.cs
+++ b/gendarme/rules/Gendarme.Rules.Performance/Test/AvoidLargeStructureTest.cs
@@ -79,7 +79,7 @@ namespace Test.Rules.Performance {
 		[Test]
 		public unsafe void StructSmall ()
 		{
-			AssertRuleSuccess<Small> ();
+			AssertRuleSuccess<span font='11'> ();
 			Assert.AreEqual (sizeof (Small), GetSize (typeof (Small)), "Size");
 		}
 

--- a/gui-compare/MainWindow.cs
+++ b/gui-compare/MainWindow.cs
@@ -461,12 +461,12 @@ public partial class MainWindow: Gtk.Window
 						tags.RemoveAt (idx);
 					break;
 
-				case "<small>":
+				case "<span font='11'>":
 					if (!tags.Contains ("small"))
 						tags.Add ("small");
 					break;
 
-				case "</small>":
+				case "<span>":
 					idx = tags.IndexOf ("small");
 					if (idx > -1)
 						tags.RemoveAt (idx);


### PR DESCRIPTION
Pango’s `<small>` font size is too small, resulting in `9pt` font. We can’t globally override this font size, so I replaced the tag with `<span font=“11”>`.

![slack-imgs com](https://user-images.githubusercontent.com/4982/29872131-93a0bea8-8d8e-11e7-8667-37ee4ec7c9da.png)