### PR TITLE
straight forward fixes for cecil 0.10

### DIFF
--- a/gendarme/console/ConsoleRunner.cs
+++ b/gendarme/console/ConsoleRunner.cs
@@ -524,7 +524,7 @@ namespace Gendarme {
 				}
 			
 				// next assembly
-				Console.Write (Path.GetFileName (e.CurrentAssembly.MainModule.FullyQualifiedName));
+				Console.Write (Path.GetFileName (e.CurrentAssembly.MainModule.FileName));
 				local.Start ();
 			}
 			

--- a/gendarme/console/XmlResultWriter.cs
+++ b/gendarme/console/XmlResultWriter.cs
@@ -87,7 +87,7 @@ namespace Gendarme {
 			foreach (AssemblyDefinition assembly in Runner.Assemblies) {
 				writer.WriteStartElement ("file");
 				writer.WriteAttributeString ("Name", assembly.FullName);
-				writer.WriteString (assembly.MainModule.FullyQualifiedName);
+				writer.WriteString (assembly.MainModule.FileName);
 				writer.WriteEndElement ();
 			}
 			writer.WriteEndElement ();

--- a/gendarme/framework/Gendarme.Framework.Helpers/PrimitiveReferences.cs
+++ b/gendarme/framework/Gendarme.Framework.Helpers/PrimitiveReferences.cs
@@ -50,7 +50,7 @@ namespace Gendarme.Framework.Helpers {
 			ModuleDefinition module = metadata.GetAssembly ().MainModule;
 			TypeReference tr;
 			if (!module.TryGetTypeReference (type.FullName, out tr))
-				tr = module.Import (type);
+				tr = module.ImportReference (type);
 			return tr;
 		}
 

--- a/gendarme/framework/Gendarme.Framework.Rocks/ModuleRocks.cs
+++ b/gendarme/framework/Gendarme.Framework.Rocks/ModuleRocks.cs
@@ -77,7 +77,7 @@ namespace Gendarme.Framework.Rocks {
 			if (self.HasSymbols)
 				return;
 
-			string image_name = self.FullyQualifiedName;
+			string image_name = self.FileName;
 			string symbol_name = image_name + ".mdb";
 			Type reader_type = null;
 

--- a/gendarme/framework/Gendarme.Framework.Rocks/TypeRocks.cs
+++ b/gendarme/framework/Gendarme.Framework.Rocks/TypeRocks.cs
@@ -73,8 +73,8 @@ namespace Gendarme.Framework.Rocks {
 				if (type != null) {
 					yield return type;
 					
-					foreach (TypeReference super in type.Interfaces) {
-						types.AddIfNew (super);
+					foreach (InterfaceImplementation super in type.Interfaces) {
+						types.AddIfNew (super.InterfaceType);
 					}
 					
 					if (type.BaseType != null)
@@ -268,11 +268,11 @@ namespace Gendarme.Framework.Rocks {
 			while (type != null) {
 				// does the type implements it itself
 				if (type.HasInterfaces) {
-					foreach (TypeReference iface in type.Interfaces) {
-						if (iface.IsNamed (nameSpace, iname))
+					foreach (InterfaceImplementation iface in type.Interfaces) {
+						if (iface.InterfaceType.IsNamed (nameSpace, iname))
 							return true;
 						//if not, then maybe one of its parent interfaces does
-						if (Implements (iface.Resolve (), nameSpace, iname))
+						if (Implements (iface.InterfaceType.Resolve (), nameSpace, iname))
 							return true;
 					}
 				}

--- a/gendarme/framework/Gendarme.Framework/AssemblyResolver.cs
+++ b/gendarme/framework/Gendarme.Framework/AssemblyResolver.cs
@@ -76,7 +76,7 @@ namespace Gendarme.Framework {
 				throw new ArgumentNullException ("assembly");
 
 			assemblies.Add (assembly.Name.Name, assembly);
-			string location = Path.GetDirectoryName (assembly.MainModule.FullyQualifiedName);
+			string location = Path.GetDirectoryName (assembly.MainModule.FileName);
 			AddSearchDirectory (location);
 		}
 

--- a/gendarme/rules/Gendarme.Rules.Design/AvoidRefAndOutParametersRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Design/AvoidRefAndOutParametersRule.cs
@@ -96,8 +96,8 @@ namespace Gendarme.Rules.Design {
 			if (td == null)
 				return false;
 
-			foreach (TypeReference intf_ref in td.Interfaces) {
-				TypeDefinition intr = intf_ref.Resolve ();
+			foreach (InterfaceImplementation intf_ref in td.Interfaces) {
+				TypeDefinition intr = intf_ref.InterfaceType.Resolve ();
 				if (intr == null)
 					continue;
 

--- a/gendarme/rules/Gendarme.Rules.Design/ConsiderAddingInterfaceRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Design/ConsiderAddingInterfaceRule.cs
@@ -190,8 +190,8 @@ namespace Gendarme.Rules.Design {
 			}
 
 			if (iface.HasInterfaces) {
-				foreach (TypeReference tr in iface.Interfaces) {
-					TypeDefinition td = tr.Resolve ();
+				foreach (InterfaceImplementation tr in iface.Interfaces) {
+					TypeDefinition td = tr.InterfaceType.Resolve ();
 					if (td == null)
 						continue;
 					if (!DoesTypeStealthilyImplementInterface (type, td))

--- a/gendarme/rules/Gendarme.Rules.Design/ImplementIComparableCorreclyRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Design/ImplementIComparableCorreclyRule.cs
@@ -109,11 +109,11 @@ namespace Gendarme.Rules.Design {
 			// rule only applies if the type implements IComparable or IComparable<T>
 			// Note: we do not use Implements rock because we do not want a recursive answer
 			bool icomparable = false;
-			foreach (TypeReference iface in type.Interfaces) {
-				if (iface.Namespace != "System")
+			foreach (InterfaceImplementation iface in type.Interfaces) {
+				if (iface.InterfaceType.Namespace != "System")
 					continue;
 				// catch both System.IComparable and System.IComparable`1<X>
-				if (iface.Name.StartsWith ("IComparable", StringComparison.Ordinal)) {
+				if (iface.InterfaceType.Name.StartsWith ("IComparable", StringComparison.Ordinal)) {
 					icomparable = true;
 					break;
 				}

--- a/gendarme/rules/Gendarme.Rules.Design/UseCorrectDisposeSignaturesRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Design/UseCorrectDisposeSignaturesRule.cs
@@ -235,8 +235,8 @@ namespace Gendarme.Rules.Design {
 		static bool DirectlyImplementsIDisposable (TypeDefinition type)
 		{
 			if (type.HasInterfaces) {
-				foreach (TypeReference candidate in type.Interfaces) {
-					if (candidate.IsNamed ("System", "IDisposable"))
+				foreach (InterfaceImplementation candidate in type.Interfaces) {
+					if (candidate.InterfaceType.IsNamed ("System", "IDisposable"))
 						return true;
 				}
 			}

--- a/gendarme/rules/Gendarme.Rules.Globalization/SatelliteResourceMismatchRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Globalization/SatelliteResourceMismatchRule.cs
@@ -185,7 +185,7 @@ namespace Gendarme.Rules.Globalization {
 			string satellitesName = mainAssembly.Name.Name + ".resources.dll";
 
 			DirectoryInfo directory = new DirectoryInfo (Path.GetDirectoryName (
-				mainAssembly.MainModule.FullyQualifiedName));
+				mainAssembly.MainModule.FileName));
 			DirectoryInfo [] subDirectories = directory.GetDirectories ();
 			foreach (DirectoryInfo dir in subDirectories) {
 				FileInfo [] files;

--- a/gendarme/rules/Gendarme.Rules.Maintainability/AvoidUnnecessarySpecializationRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Maintainability/AvoidUnnecessarySpecializationRule.cs
@@ -159,12 +159,12 @@ namespace Gendarme.Rules.Maintainability {
 		{
 			TypeDefinition ifaceDef = null;
 
-			foreach (TypeReference iface in type.Interfaces) {
+			foreach (InterfaceImplementation iface in type.Interfaces) {
 				// ignore non-cls-compliant interfaces
-				if (iface.Name.StartsWith ("_", StringComparison.Ordinal))
+				if (iface.InterfaceType.Name.StartsWith ("_", StringComparison.Ordinal))
 					continue;
 
-				TypeDefinition candidate = iface.Resolve ();
+				TypeDefinition candidate = iface.InterfaceType.Resolve ();
 				if ((candidate == null) || !candidate.IsVisible ())
 					continue; 
 
@@ -428,8 +428,8 @@ namespace Gendarme.Rules.Maintainability {
 
 		static bool IsSignatureDictatedByInterface (IMemberDefinition method, MethodSignature sig)
 		{
-			foreach (TypeReference intf_ref in method.DeclaringType.Interfaces) {
-				TypeDefinition intr = intf_ref.Resolve ();
+			foreach (InterfaceImplementation intf_ref in method.DeclaringType.Interfaces) {
+				TypeDefinition intr = intf_ref.InterfaceType.Resolve ();
 				if (intr == null)
 					continue;
 				foreach (MethodDefinition md in intr.Methods) {

--- a/gendarme/rules/Gendarme.Rules.Maintainability/RemoveDependenceOnObsoleteCodeRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Maintainability/RemoveDependenceOnObsoleteCodeRule.cs
@@ -159,9 +159,9 @@ namespace Gendarme.Rules.Maintainability {
 
 		void CheckInterfaces (TypeDefinition type)
 		{
-			foreach (TypeReference intf in type.Interfaces) {
-				if (IsObsolete (intf)) {
-					string msg = String.Format (CultureInfo.InvariantCulture, "Implement obsolete interface '{0}'.", intf);
+			foreach (InterfaceImplementation intf in type.Interfaces) {
+				if (IsObsolete (intf.InterfaceType)) {
+					string msg = String.Format (CultureInfo.InvariantCulture, "Implement obsolete interface '{0}'.", intf.InterfaceType);
 					Runner.Report (type, type.IsVisible () ? Severity.Medium : Severity.Low, Confidence.Total, msg);
 				}
 			}

--- a/gendarme/rules/Gendarme.Rules.Naming/ParameterNamesShouldMatchOverridenMethodRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Naming/ParameterNamesShouldMatchOverridenMethodRule.cs
@@ -148,8 +148,8 @@ namespace Gendarme.Rules.Naming {
 			if (!type.HasInterfaces)
 				return null;
 
-			foreach (TypeReference interfaceReference in type.Interfaces) {
-				TypeDefinition interfaceCandidate = interfaceReference.Resolve ();
+			foreach (InterfaceImplementation interfaceReference in type.Interfaces) {
+				TypeDefinition interfaceCandidate = interfaceReference.InterfaceType.Resolve ();
 				if ((interfaceCandidate == null) || !interfaceCandidate.HasMethods)
 					continue;
 

--- a/gendarme/rules/Gendarme.Rules.Naming/UseCorrectSuffixRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Naming/UseCorrectSuffixRule.cs
@@ -210,8 +210,8 @@ namespace Gendarme.Rules.Naming {
 						currentTypeSuffix = true;
 				} else {
 					// if no suffix for base type is found, we start looking through interfaces
-					foreach (TypeReference iface in current.Interfaces) {
-						if (TryGetCandidates (iface, out candidates)) {
+					foreach (InterfaceImplementation iface in current.Interfaces) {
+						if (TryGetCandidates (iface.InterfaceType, out candidates)) {
 							suffixes.AddRangeIfNew (candidates);
 							if (current == type)
 								currentTypeSuffix = true;

--- a/gendarme/rules/Gendarme.Rules.Performance/AvoidUncalledPrivateCodeRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Performance/AvoidUncalledPrivateCodeRule.cs
@@ -233,8 +233,8 @@ namespace Gendarme.Rules.Performance {
 			// check if this method is needed to satisfy an interface
 			TypeDefinition type = (method.DeclaringType as TypeDefinition);
 			if (type.HasInterfaces) {
-				foreach (TypeReference tr in type.Interfaces) {
-					TypeDefinition intf = tr.Resolve ();
+				foreach (InterfaceImplementation tr in type.Interfaces) {
+					TypeDefinition intf = tr.InterfaceType.Resolve ();
 					if (intf != null) {
 						foreach (MethodReference member in intf.Methods) {
 							if (name == member.Name)

--- a/gendarme/rules/Gendarme.Rules.Smells/AvoidLongMethodsRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Smells/AvoidLongMethodsRule.cs
@@ -277,7 +277,7 @@ namespace Gendarme.Rules.Smells {
 			int sloc = 0;
 			int current_line = -1;
 			foreach (Instruction ins in method.Body.Instructions) {
-				SequencePoint sp = ins.SequencePoint;
+				SequencePoint sp = method.DebugInformation.GetSequencePoint(ins);
 				if (sp == null)
 					continue;
 

--- a/gui-compare/CecilMetadata.cs
+++ b/gui-compare/CecilMetadata.cs
@@ -239,8 +239,8 @@ namespace GuiCompare {
 			var cache = new Dictionary<string, TypeReference> ();
 
 			foreach (var definition in WalkHierarchy (type))
-				foreach (TypeReference iface in definition.Interfaces)
-					cache [iface.FullName] = iface;
+				foreach (InterfaceImplementation iface in definition.Interfaces)
+					cache [iface.InterfaceType.FullName] = iface.InterfaceType;
 
 			return cache.Values;
 		}


### PR DESCRIPTION
To compile the mono-tools package for Fedora, I came across these changes that were necessary to build against Cecil 0.10.4.

See the posts see https://cecil.pe/post/149243207656/mono-cecil-010-beta-1 and see https://cecil.pe/post/117354704536/obsoleting-import for details.

I think these changes don't change any behaviour.

I have split each category of changes in separate commits to make the review easier.