### PR TITLE
Cecil 0.10: The property VariableReference.Name has been removed

### DIFF
--- a/gendarme/framework/Gendarme.Framework.Rocks/VariableDefinitionRocks.cs
+++ b/gendarme/framework/Gendarme.Framework.Rocks/VariableDefinitionRocks.cs
@@ -43,7 +43,7 @@ namespace Gendarme.Framework.Rocks {
 			if (self == null)
 				return false;
 
-			string name = self.Name;
+			string name = String.Empty; // self.Name is not valid anymore since Mono.Cecil 0.10
 			if (String.IsNullOrEmpty (name))
 				return true;
 
@@ -54,7 +54,8 @@ namespace Gendarme.Framework.Rocks {
 		{
 			if (self == null)
 				return String.Empty;
-			return !string.IsNullOrEmpty (self.Name) ? self.Name : "V_" + self.Index.ToString (CultureInfo.InvariantCulture);
+			string name = String.Empty; // self.Name is not valid anymore since Mono.Cecil 0.10
+			return !string.IsNullOrEmpty (name) ? name : "V_" + self.Index.ToString (CultureInfo.InvariantCulture);
 		}
 	}
 }

--- a/gendarme/rules/Gendarme.Rules.Concurrency/ProtectCallToEventDelegatesRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Concurrency/ProtectCallToEventDelegatesRule.cs
@@ -171,7 +171,8 @@ namespace Gendarme.Rules.Concurrency {
 					// look for the variable, if it's not then stop analysis
 					VariableDefinition load = caller.GetVariable (method);
 					if ((load != null) && !CheckVariable (method, caller, load)) {
-						string msg = String.Format (CultureInfo.InvariantCulture, "Variable '{0}' does not seems to be checked against null.", load.Name);
+						string name = String.Empty; // load.Name is not valid since Cecil 0.10
+						string msg = String.Format (CultureInfo.InvariantCulture, "Variable '{0}' does not seems to be checked against null.", name);
 						Runner.Report (method, ins, Severity.High, Confidence.Normal, msg);
 					}
 				}

--- a/gendarme/rules/Gendarme.Rules.Correctness/AvoidCodeWithSideEffectsInConditionalCodeRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Correctness/AvoidCodeWithSideEffectsInConditionalCodeRule.cs
@@ -145,8 +145,10 @@ namespace Gendarme.Rules.Correctness {
 					
 					} else if (ins.IsStoreLocal ()) {
 						VariableDefinition vd = ins.GetVariable (method);
-						if (!vd.IsGeneratedName ())
-							name = "local " + vd.Name;
+						if (!vd.IsGeneratedName ()) {
+							string variableName = String.Empty; // vd.Name is not valid since Cecil 0.10
+							name = "local " + variableName;
+						}
 					
 					} else if (ins.OpCode.Code == Code.Stfld || ins.OpCode.Code == Code.Stsfld) {
 						FieldReference fr = ins.Operand as FieldReference;

--- a/gendarme/rules/Gendarme.Rules.Correctness/EnsureLocalDisposalRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Correctness/EnsureLocalDisposalRule.cs
@@ -344,7 +344,8 @@ namespace Gendarme.Rules.Correctness {
 			string tname = variable.VariableType.Name;
 			if (variable.IsGeneratedName ())
 				return String.Format (CultureInfo.InvariantCulture, "of type '{0}' ", tname);
-			return String.Format (CultureInfo.InvariantCulture, "'{0}' of type '{1}' ", variable.Name, tname);
+			string variableName = String.Empty; // variable.Name is not valid anymore since Cecil 0.10
+			return String.Format (CultureInfo.InvariantCulture, "'{0}' of type '{1}' ", variableName, tname);
 		}
 
 		static OpCodeBitmask BuildCallsAndNewobjOpCodeBitmask ()

--- a/gendarme/rules/Gendarme.Rules.Correctness/ReviewDoubleAssignmentRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Correctness/ReviewDoubleAssignmentRule.cs
@@ -114,7 +114,8 @@ namespace Gendarme.Rules.Correctness {
 			if (stfld.TraceBack (method).GetOperand (method) != next.TraceBack (method).GetOperand (method))
 				return String.Empty;
 
-			return String.Format (CultureInfo.InvariantCulture, "Instance field '{0}' on same variable '{1}'.", fd1.Name, vd1.Name);
+			string vd1Name = String.Empty; // vd1.Name is not valid anymore since Cecil 0.10
+			return String.Format (CultureInfo.InvariantCulture, "Instance field '{0}' on same variable '{1}'.", fd1.Name, vd1Name);
 		}
 
 		static string CheckDoubleAssignement (MethodDefinition method, Instruction ins, Instruction next)
@@ -142,7 +143,8 @@ namespace Gendarme.Rules.Correctness {
 					if (vd1.Index != vd2.Index)
 						return String.Empty;
 
-					return String.Format (CultureInfo.InvariantCulture, "Local variable '{0}'.", vd1.Name);
+					string vd1Name = String.Empty; // vd1.Name is not valid since Cecil 0.10
+					return String.Format (CultureInfo.InvariantCulture, "Local variable '{0}'.", vd1Name);
 				} else if (next.OpCode.Code == Code.Stfld) {
 					// instance fields are a bit more complex...
 					return CheckDoubleAssignementOnInstanceFields (method, ins, next);

--- a/gendarme/rules/Gendarme.Rules.Maintainability/PreferStringIsNullOrEmptyRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Maintainability/PreferStringIsNullOrEmptyRule.cs
@@ -111,10 +111,15 @@ namespace Gendarme.Rules.Maintainability {
 			case Code.Ldloc_2:
 			case Code.Ldloc_3:
 				int vindex = ins.OpCode.Code - Code.Ldloc_0;
-				return method.Body.Variables [vindex].Name;
+				string name;
+				if (method.DebugInformation.TryGetName(method.Body.Variables [vindex], out name)) {
+					return name;
+				}
+				return String.Empty;
 			case Code.Ldloc:
 			case Code.Ldloc_S:
-				return (ins.Operand as VariableDefinition).Name;
+				//return (ins.Operand as VariableDefinition).Name; not valid since Cecil 0.10
+				return String.Empty;
 			default:
 				object o = ins.Operand;
 				MemberReference mr = (o as MemberReference);

--- a/gendarme/rules/Gendarme.Rules.Maintainability/VariableNamesShouldNotMatchFieldNamesRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Maintainability/VariableNamesShouldNotMatchFieldNamesRule.cs
@@ -113,8 +113,9 @@ namespace Gendarme.Rules.Maintainability {
 						// if the name is compiler generated or if we do not have debugging symbols...
 						if (var.IsGeneratedName ())
 							continue;
-						if (fields.Contains (var.Name))
-							Runner.Report (method, Severity.Medium, Confidence.Normal, var.Name);
+						// var.Name is not valid anymore since Cecil 0.10
+						//if (fields.Contains (var.Name))
+						//	Runner.Report (method, Severity.Medium, Confidence.Normal, var.Name);
 					}
 				}
 			}

--- a/gendarme/rules/Gendarme.Rules.Performance/RemoveUnusedLocalVariablesRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Performance/RemoveUnusedLocalVariablesRule.cs
@@ -133,8 +133,9 @@ namespace Gendarme.Rules.Performance {
 					if (variable.IsGeneratedName ())
 						continue;
 
+					string variableName = String.Empty; // variable.Name is not valid anymore since Cecil 0.10
 					string s = String.Format (CultureInfo.InvariantCulture, "Variable '{0}' of type '{1}'", 
-						variable.Name, variable.VariableType.GetFullName ());
+						variableName, variable.VariableType.GetFullName ());
 					Runner.Report (method, Severity.Low, Confidence.Normal, s);
 				}
 			}

--- a/gendarme/rules/Gendarme.Rules.Portability/DoNotHardcodePathsRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Portability/DoNotHardcodePathsRule.cs
@@ -337,8 +337,12 @@ namespace Gendarme.Rules.Portability {
 				CheckIdentifier ((afterLdstr.Operand as FieldReference).Name);
 				break;
 			default:
-				if (afterLdstr.IsStoreLocal ())
-					CheckIdentifier (afterLdstr.GetVariable (method_body.Method).Name);
+				if (afterLdstr.IsStoreLocal ()) {
+					string name;
+					if (method_body.Method.DebugInformation.TryGetName(afterLdstr.GetVariable (method_body.Method), out name)) {
+						CheckIdentifier (name);
+					}
+				}
 				else
 					return false;
 				break;


### PR DESCRIPTION
related to the pull request #64 
This change is possibly breaking. Though in the release notes of Cecil, it says: "This has never been represented in the metadata, and is actually incorrect."
see https://cecil.pe/post/149243207656/mono-cecil-010-beta-1

I tried to work around it, by either returning an empty string, or trying to get the method involved and find the variable there.