### PR TITLE
Fix errors arising from NullableAttribute analysis

### DIFF
--- a/gendarme/framework/Gendarme.Framework/BasicIgnoreList.cs
+++ b/gendarme/framework/Gendarme.Framework/BasicIgnoreList.cs
@@ -61,11 +61,11 @@ namespace Gendarme.Framework {
 
 		public void Add (string rule, IMetadataTokenProvider metadata)
 		{
-            if (rule is null) {
+			if (rule is null) {
 				Console.Error.WriteLine("Attempted to add null rule");
-                return;
-            }
-            HashSet<IMetadataTokenProvider> list;
+				return;
+			}
+			HashSet<IMetadataTokenProvider> list;
 			if (!ignore.TryGetValue (rule, out list)) {
 				list = new HashSet<IMetadataTokenProvider> ();
 				ignore.Add (rule, list);

--- a/gendarme/framework/Gendarme.Framework/BasicIgnoreList.cs
+++ b/gendarme/framework/Gendarme.Framework/BasicIgnoreList.cs
@@ -61,7 +61,11 @@ namespace Gendarme.Framework {
 
 		public void Add (string rule, IMetadataTokenProvider metadata)
 		{
-			HashSet<IMetadataTokenProvider> list;
+            if (rule is null) {
+				Console.Error.WriteLine("Attempted to add null rule");
+                return;
+            }
+            HashSet<IMetadataTokenProvider> list;
 			if (!ignore.TryGetValue (rule, out list)) {
 				list = new HashSet<IMetadataTokenProvider> ();
 				ignore.Add (rule, list);

--- a/gendarme/rules/Gendarme.Rules.Design/AttributeArgumentsShouldHaveAccessorsRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Design/AttributeArgumentsShouldHaveAccessorsRule.cs
@@ -129,7 +129,8 @@ namespace Gendarme.Rules.Design {
 					// pascal case it
 					if (param.Name.Length == 0) {
 						Console.Error.WriteLine("Unexpected empty constructor parameter.\n  Type: {0}\n  Method: {1}", type.FullName, constructor);
-						continue; }
+						continue;
+					}
 					string correspondingPropertyName = Char.ToUpper (param.Name [0], CultureInfo.InvariantCulture).ToString (CultureInfo.InvariantCulture) +
 						param.Name.Substring (1);
 					if (!allProperties.Contains (correspondingPropertyName)) {

--- a/gendarme/rules/Gendarme.Rules.Design/AttributeArgumentsShouldHaveAccessorsRule.cs
+++ b/gendarme/rules/Gendarme.Rules.Design/AttributeArgumentsShouldHaveAccessorsRule.cs
@@ -126,7 +126,10 @@ namespace Gendarme.Rules.Design {
 					continue;
 
 				foreach (ParameterDefinition param in constructor.Parameters) {
-					 // pascal case it
+					// pascal case it
+					if (param.Name.Length == 0) {
+						Console.Error.WriteLine("Unexpected empty constructor parameter.\n  Type: {0}\n  Method: {1}", type.FullName, constructor);
+						continue; }
 					string correspondingPropertyName = Char.ToUpper (param.Name [0], CultureInfo.InvariantCulture).ToString (CultureInfo.InvariantCulture) +
 						param.Name.Substring (1);
 					if (!allProperties.Contains (correspondingPropertyName)) {


### PR DESCRIPTION
Running gendarme on my .NET 6 project fails sometimes. Exception point at two locations, and simplest solution is to add validation

![image](https://user-images.githubusercontent.com/37376850/190411887-359ed2f5-fdd7-4dd3-82d1-caedf9386aa1.png)

![image](https://user-images.githubusercontent.com/37376850/190412357-43eadbb7-7c50-4cba-a5d6-238534ec5f1c.png)
